### PR TITLE
Integración de la funcionalidad para obtener los 5 episodios mejor evaluados de una serie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
 - Se añadió el endpoint `GET /series/categoria/{nombreGenero}` en `SerieController` para obtener series filtradas por género.
 - Se añadió el método `obtenerSeriesPorCategoria` en `SerieService` para obtener series por género, utilizando el método `findByGenero` en `SerieRepository`.
 - El método `obtenerSeriesPorCategoria` convierte el nombre del género en español a su representación en la clase `Categoria` y devuelve una lista de `SerieDTO` correspondientes.
+- Se añadió el endpoint `GET /series/{id}/temporadas/top` en la clase `SerieController`.
+    - Este endpoint permite obtener los 5 episodios mejor evaluados de una serie específica mediante su ID.
+    - El método delega la lógica de negocio al método `obtenerTopEpisodios` en `SerieService`.
+- Se añadió el método `obtenerTopEpisodios(Long id)` en la clase `SerieService`.
+    - Este método obtiene los 5 episodios con la mejor evaluación de una serie dada.
+    - Utiliza la consulta personalizada `topEpisodiosPorSerie` definida en `SerieRepository`.
+- Se añadió la consulta personalizada `topEpisodiosPorSerie` en `SerieRepository`.
+    - La consulta utiliza un `JOIN` entre la serie y sus episodios para obtener los 5 episodios mejor evaluados de una serie específica.
 
 ### **Changed**
 - Se refactorizó la clase `ScreenmatchApplication` para mejorar la modularidad y la estructura del proyecto.

--- a/CURSO_03.md
+++ b/CURSO_03.md
@@ -24,3 +24,11 @@
 - **Utilizar buenas prácticas de extracción de métodos**. Aplicamos principios de la orientación a objetos, extrayendo métodos que eran comunes en el código, facilitando el mantenimiento.
 - **Crear una url fija para el Controller**. Usamos el @RequestMapping para que todas las urls mapeadas por el controlador de series tengan como prefijo el “/series”.
 - **Retornar los datos de una sola serie**. Para buscar una serie, necesitamos que su id sea pasado como parámetro. Conocimos el @PathVariable, que nos ayuda en ese objetivo.
+
+# Aula 04
+
+## En esta clase, aprendiste cómo:
+- **Trabajar de forma colaborativa**. Vimos que es importante siempre probar exhaustivamente el código, más aún con registros diferentes. Solo así tenemos la confirmación de que nuestras búsquedas están correctas.
+- **Pasar parámetros en la url**. Usamos nuevamente la anotación @PathVariable y vimos que puede ser utilizada tanto con números como con cadenas. Para que funcione, basta con que pasemos el nombre del parámetro entre llaves en la url del @GetMapping, exactamente como está declarado en la función.
+- **Comparar streams y búsquedas en la base de datos**. Aprendimos que podemos utilizar tanto streams como consultas de la base de datos, no necesitamos restringirnos al uso exclusivo de uno de ellos. Basta con que analicemos la complejidad de las búsquedas, filtros y operaciones que haremos.
+- **Desarrollar una aplicación de forma incremental**. Al trabajar en la integración del front con el back-end, identificamos, a lo largo del tiempo, los requisitos necesarios para que todo funcione en conjunto. El trabajo incremental es muy común en el ambiente de desarrollo.

--- a/src/main/java/com/aluracursos/screenmatch/controller/SerieController.java
+++ b/src/main/java/com/aluracursos/screenmatch/controller/SerieController.java
@@ -52,4 +52,9 @@ public class SerieController {
     public List<SerieDTO> obtenerSeriesPorCategoria(@PathVariable String nombreGenero) {
         return servicio.obtenerSeriesPorCategoria(nombreGenero);
     }
+
+    @GetMapping("/{id}/temporadas/top")
+    public List<EpisodioDTO> obtenerTopEpisodios(@PathVariable Long id) {
+        return servicio.obtenerTopEpisodios(id);
+    }
 }

--- a/src/main/java/com/aluracursos/screenmatch/repository/SerieRepository.java
+++ b/src/main/java/com/aluracursos/screenmatch/repository/SerieRepository.java
@@ -1,6 +1,5 @@
 package com.aluracursos.screenmatch.repository;
 
-import com.aluracursos.screenmatch.dto.EpisodioDTO;
 import com.aluracursos.screenmatch.model.Categoria;
 import com.aluracursos.screenmatch.model.Episodio;
 import com.aluracursos.screenmatch.model.Serie;
@@ -37,4 +36,7 @@ public interface SerieRepository extends JpaRepository<Serie, Long> {
 
     @Query("SELECT e FROM Serie s JOIN s.episodios e WHERE s.id = :id AND e.temporada = :numeroTemporada")
     List<Episodio> obtenerTemporadasPorNumero(Long id, Long numeroTemporada);
+
+    @Query("SELECT e FROM Serie s JOIN s.episodios e WHERE s = :serie ORDER BY e.evaluacion DESC LIMIT 5")
+    List<Episodio> topEpisodiosPorSerie(Serie serie);
 }

--- a/src/main/java/com/aluracursos/screenmatch/service/SerieService.java
+++ b/src/main/java/com/aluracursos/screenmatch/service/SerieService.java
@@ -3,6 +3,7 @@ package com.aluracursos.screenmatch.service;
 import com.aluracursos.screenmatch.dto.EpisodioDTO;
 import com.aluracursos.screenmatch.dto.SerieDTO;
 import com.aluracursos.screenmatch.model.Categoria;
+import com.aluracursos.screenmatch.model.Episodio;
 import com.aluracursos.screenmatch.model.Serie;
 import com.aluracursos.screenmatch.repository.SerieRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,5 +64,14 @@ public class SerieService {
     public List<SerieDTO> obtenerSeriesPorCategoria(String nombreGenero) {
         Categoria categoria = Categoria.fromEspanol(nombreGenero);
         return convierteDatos(repository.findByGenero(categoria));
+    }
+
+    public List<EpisodioDTO> obtenerTopEpisodios(Long id) {
+        var serie = repository.findById(id).get();
+        return repository.topEpisodiosPorSerie(serie)
+                .stream()
+                .map(e -> new EpisodioDTO(e.getTemporada(),e.getTitulo(),
+                        e.getNumeroEpisodio()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Este pull request introduce la funcionalidad que permite obtener los 5 episodios mejor evaluados de una serie específica. Los cambios realizados son los siguientes:

1. **Endpoint en `SerieController`**:
   - Se añadió el endpoint `GET /series/{id}/temporadas/top` en la clase `SerieController`.
   - Este endpoint recibe el ID de una serie y devuelve los 5 episodios mejor evaluados de esa serie.
   - La lógica de negocio es delegada al método `obtenerTopEpisodios` de la clase `SerieService`.

2. **Método en `SerieService`**:
   - Se añadió el método `obtenerTopEpisodios(Long id)` en la clase `SerieService`.
   - Este método obtiene los 5 episodios con la mejor evaluación de una serie dada.
   - Utiliza la consulta personalizada `topEpisodiosPorSerie` definida en `SerieRepository`.

3. **Consulta personalizada en `SerieRepository`**:
   - Se añadió la consulta `topEpisodiosPorSerie` en `SerieRepository`.
   - Esta consulta utiliza un `JOIN` entre la serie y sus episodios, y se ordena por evaluación para obtener los 5 episodios mejor evaluados de una serie.

### Beneficios:
- Mejora la experiencia del usuario al permitirle ver rápidamente los episodios mejor valorados de una serie.
- Optimiza el proceso de obtención de los episodios mediante consultas directas a la base de datos.